### PR TITLE
Fixed plot_linear_regression_wave() not displaying plots on some devices

### DIFF
--- a/mglearn/plot_linear_regression.py
+++ b/mglearn/plot_linear_regression.py
@@ -30,3 +30,4 @@ def plot_linear_regression_wave():
     ax.legend(["model", "training data"], loc="best")
     ax.grid(True)
     ax.set_aspect('equal')
+    return plt.show()


### PR DESCRIPTION
This probably extends to other functions but tbh this was the only one I needed at the time. Can add support on other methods later.

Tested for devices that worked already and broken device.